### PR TITLE
Bump Golang version; update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # BugBountyScanner
 
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/chvancooten/bugbountyscanner/Docker%20Build)](https://github.com/chvancooten/BugBountyScanner/actions)
-[![Docker Build Badge](https://img.shields.io/docker/cloud/build/chvancooten/bugbountyscanner)](https://hub.docker.com/r/chvancooten/bugbountyscanner/)
+[![Docker Pulls Badge](https://img.shields.io/docker/pulls/chvancooten/bugbountyscanner)](https://hub.docker.com/r/chvancooten/bugbountyscanner/)
 [![Docker Automated Badge](https://img.shields.io/docker/cloud/automated/chvancooten/bugbountyscanner)](https://hub.docker.com/r/chvancooten/bugbountyscanner/)
 [![Docker Image Size Badge](https://img.shields.io/docker/image-size/chvancooten/bugbountyscanner)](https://hub.docker.com/r/chvancooten/bugbountyscanner/)
-[![Docker Pulls Badge](https://img.shields.io/docker/pulls/chvancooten/bugbountyscanner)](https://hub.docker.com/r/chvancooten/bugbountyscanner/)
 [![PRs Welcome](https://img.shields.io/badge/Contributions-Welcome-brightgreen.svg)](http://makeapullrequest.com)
 
 A Bash script and Docker image for Bug Bounty reconnaissance, intended for headless use. Low on resources, high on information output.

--- a/setup.sh
+++ b/setup.sh
@@ -67,9 +67,9 @@ rm -rf /var/lib/apt/lists/*
 go version &> /dev/null
 if [ $? -ne 0 ]; then
     echo "[*] Installing Golang..."
-    wget -q https://golang.org/dl/go1.17.4.linux-amd64.tar.gz
-    tar -xvf go1.17.4.linux-amd64.tar.gz -C /usr/local >/dev/null
-    rm -rf ./go1.17.4.linux-amd64.tar.gz >/dev/null
+    wget -q https://golang.org/dl/go1.19.2.linux-amd64.tar.gz
+    tar -xvf go1.19.2.linux-amd64.tar.gz -C /usr/local >/dev/null
+    rm -rf ./go1.19.2.linux-amd64.tar.gz >/dev/null
     export GOROOT="/usr/local/go"
     export GOPATH="$homeDir/go"
     export PATH="$PATH:${GOPATH}/bin:${GOROOT}/bin:${PATH}"


### PR DESCRIPTION
Docker build was failing since the latest Nuclei did not work with the older Golang version. Updated Golang to the latest version to fix. Pushed new Docker image with latest versions. Also made some changes to the badges in README.md.